### PR TITLE
Remove Twitter oEmbed XML response option

### DIFF
--- a/providers/twitter.json
+++ b/providers/twitter.json
@@ -6,8 +6,7 @@
 	"url":         "https://twitter.com/",
 	"icon":        "http://oEmbed.ly/providers/twitter.png",
 	"endpoints": [
-		"https://api.twitter.com/1/statuses/oembed.json",
-		"https://api.twitter.com/1/statuses/oembed.xml"
+		"https://publish.twitter.com/oembed"
 	],
 	"regex": [
 		"#(http:|https:)?//(www.)?twitter.com/.+?/status(es)?/.*#i"


### PR DESCRIPTION
Twitter announced an [XML oEmbed response will not be returned after May 1](https://twittercommunity.com/t/deprecation-of-xml-response-type-for-single-tweet-oembed/62013).
- Update Twitter endpoint to remove XML
- Use the new, preferred oEmbed endpoint for single Tweet
